### PR TITLE
v0.2.6 | Ability to change Claude's model version

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,7 @@ for chat in all_chat_ids:
     client.delete_chat(chat)
 
 # Or by using a shortcut utility
-#
-# client.delete_all_chats()
+client.delete_all_chats()
 ```
 
 ## Tips
@@ -201,6 +200,7 @@ If you'd like to set a proxy for all requests, follow this example:
 
 ```py
 from claude2_api.client import HTTPProxy, ClaudeAPIClient
+from claude2_api.session import SessionData
 
 # Create HTTPProxy instance
 http_proxy = HTTPProxy(
@@ -209,9 +209,24 @@ http_proxy = HTTPProxy(
     use_ssl=False           # Set to True if proxy uses HTTPS schema
 )
 
-# session = SessionData(...)
+session = SessionData(...)
+
 # Give the proxy instance to ClaudeAPIClient constructor, along with session data.
 client = ClaudeAPIClient(session, proxy=http_proxy)
+```
+
+### Changing Claude model
+
+In case you have accounts that are unable to migrate to newer models, you can override the `model_name` string parameter of `ClaudeAPIClient` constructor.
+
+```py
+from claude2_api.client import ClaudeAPIClient
+from claude2_api.session import SessionData
+
+session = SessionData(...)
+
+# Defaults to claude-2.1
+client = ClaudeAPIClient(session, model_name="claude-2.0")
 ```
 
 ______

--- a/claude2_api/client.py
+++ b/claude2_api/client.py
@@ -105,7 +105,11 @@ class ClaudeAPIClient:
     __BASE_URL = "https://claude.ai"
 
     def __init__(
-        self, session: SessionData, proxy: HTTPProxy = None, timeout: float = 240
+        self,
+        session: SessionData,
+        proxy: HTTPProxy = None,
+        model_name: str = "claude-2.1",
+        timeout: float = 240,
     ) -> None:
         """
         Constructs a `ClaudeAPIClient` instance using provided `SessionData`,
@@ -117,6 +121,12 @@ class ClaudeAPIClient:
         Raises `ValueError` in case of failure
 
         """
+        if model_name not in {"claude-2.0", "claude-2.1"}:
+            raise ValueError(
+                "model_name must be either one of 'claude-2.0' or 'claude-2.1' strings"
+            )
+
+        self.model_name = model_name
         self.timeout = timeout
         self.proxy = proxy
         self.__session = session
@@ -473,8 +483,7 @@ class ClaudeAPIClient:
             attachments = [
                 a
                 for a in [
-                    self.__prepare_file_attachment(path)
-                    for path in attachment_paths
+                    self.__prepare_file_attachment(path) for path in attachment_paths
                 ]
                 if a
             ]
@@ -486,7 +495,7 @@ class ClaudeAPIClient:
                 "completion": {
                     "prompt": prompt,
                     "timezone": self.timezone,
-                    "model": "claude-2.1",
+                    "model": self.model_name,
                 },
                 "organization_uuid": self.__session.organization_id,
                 "conversation_uuid": chat_id,

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(
 
 setup(
     name="unofficial-claude2-api",
-    version="0.2.5",
+    version="0.2.6",
     author="st1vms",
     author_email="stefano.maria.salvatore@gmail.com",
     description=__DESCRIPTION,


### PR DESCRIPTION
## CHANGELOG

- Added `model_name` string parameter into `ClaudeAPIClient` constructor, can be either `claude-2.0` or `claude-2.1`