### PR TITLE
Fix for #12, waiting to push version 0.2.7

### DIFF
--- a/claude2_api/__init__.py
+++ b/claude2_api/__init__.py
@@ -2,16 +2,19 @@
 from .client import (
     ClaudeAPIClient,
     SendMessageResponse,
-    MessageRateLimitError,
     HTTPProxy,
 )
 from .session import SessionData, get_session_data
+from .errors import ClaudeAPIError, MessageRateLimitError, OverloadError
+
 
 __all__ = [
     "ClaudeAPIClient",
     "SendMessageResponse",
-    "MessageRateLimitError",
     "HTTPProxy",
     "SessionData",
     "get_session_data",
+    "MessageRateLimitError",
+    "ClaudeAPIError",
+    "OverloadError",
 ]

--- a/claude2_api/errors.py
+++ b/claude2_api/errors.py
@@ -1,0 +1,46 @@
+"""custom errors module"""
+from time import time
+from datetime import datetime
+
+
+class ClaudeAPIError(Exception):
+    """Base class for ClaudeAPIClient exceptions"""
+
+
+class MessageRateLimitError(ClaudeAPIError):
+    """Exception for MessageRateLimit
+    Will hold three variables:
+
+    - `reset_timestamp`: Timestamp in seconds at which the rate limit expires.
+
+    - `reset_date`: Formatted datetime string (%Y-%m-%d %H:%M:%S) at which the rate limit expires.
+
+    - `sleep_sec`: Amount of seconds to wait before reaching the expiration timestamp
+    (Auto calculated based on reset_timestamp)"""
+
+    def __init__(self, reset_timestamp: int, *args: object) -> None:
+        super().__init__(*args)
+        self.reset_timestamp: int = reset_timestamp
+        """
+        The timestamp in seconds when the message rate limit will be reset
+        """
+        self.reset_date: str = datetime.fromtimestamp(reset_timestamp).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
+        """
+        Formatted datetime string of expiration timestamp in the format %Y-%m-%d %H:%M:%S
+        """
+
+    @property
+    def sleep_sec(self) -> int:
+        """
+        The amount of seconds to wait before reaching the reset_timestamp
+        """
+        return int(abs(time() - self.reset_timestamp)) + 1
+
+
+class OverloadError(ClaudeAPIError):
+    """Exception wrapping the Claude's overload_error"""
+
+    def __init__(self, *args: object) -> None:
+        super().__init__(*args)

--- a/claude2_api/session.py
+++ b/claude2_api/session.py
@@ -9,7 +9,7 @@ from selgym.gym import (
     get_default_firefox_profile,
     wait_element_by,
     click_element,
-    By
+    By,
 )
 
 
@@ -32,7 +32,7 @@ class SessionData:
     Browser User agent
     """
 
-    organization_id:Optional[str] = None
+    organization_id: Optional[str] = None
     """
     Claude's account organization ID, will be auto retrieved if None
     """
@@ -80,8 +80,8 @@ def get_session_data(profile: str = "", quiet: bool = False) -> SessionData | No
         pre = wait_element_by(driver, By.CSS_SELECTOR, json_text_csss)
         if pre.text:
             j = json_loads(pre.text)
-            if j and len(j) >= 1 and 'uuid' in j[0]:
-                org_id = j[0]['uuid']
+            if j and len(j) >= 1 and "uuid" in j[0]:
+                org_id = j[0]["uuid"]
 
         return SessionData(cookie_string, user_agent, org_id)
     finally:

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(
 
 setup(
     name="unofficial-claude2-api",
-    version="0.2.6",
+    version="0.2.7",
     author="st1vms",
     author_email="stefano.maria.salvatore@gmail.com",
     description=__DESCRIPTION,
@@ -31,6 +31,7 @@ setup(
     ],
     python_requires=">=3.10",
     install_requires=[
+        "requests",
         "selgym",
         "curl_cffi",
         "tzlocal",


### PR DESCRIPTION
## CHANGELOG:

- Changed `send_message` response parsing strategy
- `error_response` is now called `raw_answer`, and it holds the `response.content` from the `send_message` response, used for inspections purposes.
- Implemented a new Claude error `OverloadError`

## MISCELLANOUS IMPROVEMENTS

- All the api errors now inherits from `ClaudeAPIError`
- Moved errors into `claude2_api.errors`
- Replaced `requests.Session` with `requests.post` in `__prepare_file_attachment`, as the headers were incorrectly set.
- Clarified the error "[400] Unable to prepare file attachment" in the Troubleshotting section of `README.md`