### PR TITLE
`model_name` defaults to None (latest model)

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ __________
 
 ### Changing Claude model
 
-In case you have accounts that are unable to migrate to newer models, you can override the `model_name` string parameter of `ClaudeAPIClient` constructor.
+In case you have accounts that are unable to migrate to latest model, you can override the `model_name` string parameter of `ClaudeAPIClient` constructor.
 
 ```py
 from claude2_api.client import ClaudeAPIClient
@@ -264,7 +264,8 @@ from claude2_api.session import SessionData
 
 session = SessionData(...)
 
-# Defaults to claude-2.1
+# Defaults to None (latest Claude model)
+# Can be either claude-2.0 or claude-2.1
 client = ClaudeAPIClient(session, model_name="claude-2.0")
 ```
 

--- a/claude2_api/client.py
+++ b/claude2_api/client.py
@@ -120,8 +120,8 @@ class ClaudeAPIClient:
     def __init__(
         self,
         session: SessionData,
+        model_name: str = None,
         proxy: ClaudeProxyT = None,
-        model_name: str = "claude-2.1",
         timeout: float = 240,
     ) -> None:
         """
@@ -134,9 +134,9 @@ class ClaudeAPIClient:
         Raises `ValueError` in case of failure
 
         """
-        if model_name not in {"claude-2.0", "claude-2.1"}:
+        if model_name is not None and model_name not in {"claude-2.0", "claude-2.1"}:
             raise ValueError(
-                "model_name must be either one of 'claude-2.0' or 'claude-2.1' strings"
+                "model_name must be either None or one of 'claude-2.0' or 'claude-2.1' strings"
             )
 
         self.model_name: str = model_name
@@ -567,14 +567,17 @@ class ClaudeAPIClient:
             + f"{chat_id}/completion"
         )
 
+        payload = {
+            "attachments": attachments,
+            "files": [],
+            "prompt": prompt,
+            "timezone": self.timezone,
+        }
+        if self.model_name is not None:
+            payload["model"] = self.model_name
+
         payload = dumps(
-            {
-                "attachments": attachments,
-                "files": [],
-                "model": self.model_name,
-                "prompt": prompt,
-                "timezone": self.timezone,
-            },
+            payload,
             indent=None,
             separators=(",", ":"),
         )

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(
 
 setup(
     name="unofficial-claude2-api",
-    version="0.2.9",
+    version="0.3.0",
     author="st1vms",
     author_email="stefano.maria.salvatore@gmail.com",
     description=__DESCRIPTION,


### PR DESCRIPTION
Would need some confirmations before merging...

By not setting `model_name` in `ClaudeAPIClient` (leaving to None by default) it should avoid setting the "model" parameter when calling `/completion` endpoint using `send_message`, thus allowing to use latest Claude model.